### PR TITLE
Fix `pair_items`

### DIFF
--- a/include/pair_items.h
+++ b/include/pair_items.h
@@ -14,24 +14,37 @@ concept SizedContainer = requires(T t) {
 
 template <SizedContainer T>
 class pair_items_view {
-    T& container;
+    T* container;
 
     struct iterator {
-        const T& container;
+        const T* container;
         std::size_t current;
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::pair<typename T::value_type, typename T::value_type>;
 
-        iterator(const T& container, std::size_t start) : container(container), current(start) {}
+        iterator() = default;
+        iterator(const T* container, std::size_t start) : container(container), current(start) {}
+        iterator(const iterator&) = default;
+        iterator& operator=(const iterator&) = default;
 
         std::pair<typename T::value_type, typename T::value_type> operator*() const {
-            auto [firstInd, secondInd] = indexes(current, container.size());
-            return {container[firstInd], container[secondInd]};
+            auto [firstInd, secondInd] = indexes(current, container->size());
+            return {(*container)[firstInd], (*container)[secondInd]};
         }
 
         iterator& operator++() {
             ++current;
             return *this;
         }
+        iterator operator++(int) {
+            iterator copy = *this;
+            ++current;
+            return copy;
+        }
 
+        bool operator==(const iterator& other) const {
+            return current == other.current;
+        }
         bool operator!=(const iterator& other) const {
             return current != other.current;
         }
@@ -54,13 +67,13 @@ class pair_items_view {
 
 
 public:
-    pair_items_view(T& container) : container(container) {}
+    pair_items_view(T& container) : container(std::addressof(container)) {}
 
     iterator begin() { return iterator(container, 0); }
     iterator end() { return iterator(container, size()); }
 
     std::size_t size() const {
-        return container.size() * (container.size() - 1) / 2;
+        return container->size() * (container->size() - 1) / 2;
     }
 };
 }

--- a/pair_items.cpp
+++ b/pair_items.cpp
@@ -18,10 +18,10 @@ int main()
     {
         std::cout << first << " " << second << std::endl;
     }
-
-//    auto x = tc::views::pair_items_view(numbers) | std::views::transform([](const auto& [first, second]) {
-//        return first + second;
-//    });
+    
+    auto x = std::views::transform(tc::views::pair_items_view(numbers), [](const auto& p) {
+        return p.first + p.second;
+    });
 
 
     return 0;


### PR DESCRIPTION
Changes I made:

- In `pair_items.cpp`, you try to use structured bindings in a lambda parameter list, which is unfortunately not allowed. I use a function called [`uncurry`](https://github.com/TartanLlama/ranges/blob/main/include/tl/functional/curry.hpp) for this.
- Ranges need to be moveable. The usual way to do this is to store the underlying view directly in the range adaptor, and have a template deduction guide that deduces `std::views::all_t`, like [here](https://github.com/TartanLlama/ranges/blob/main/include/tl/cartesian_product.hpp#L250). For simplicity, I just changed the reference that you store to a pointer.
- Iterators need to be moveable. Yours can be copyable so long as the reference is made into a pointer.
- You need to declare a `difference_type` (even if you don't use it) and a `value_type`.
- You need to implement `operator++(int)` and `operator==`.