### PR TITLE
using range adaptor

### DIFF
--- a/pair_items.cpp
+++ b/pair_items.cpp
@@ -9,19 +9,46 @@
 
 #include "include/pair_items.h"
 
+
 int main()
 {
     std::cout << "Pair Items View Tests" << std::endl;
 
-    std::vector<int> numbers = {1, 2, 3, 4, 5};
-    for (const auto& [first, second] : tc::views::pair_items_view(numbers))
+
+      const std::vector<int> numbers = {1, 2, 3, 4, 5};
+//    for (const auto& [first, second] : tc::views::pair_items_view(numbers))
+//    {
+//        std::cout << first << " " << second << std::endl;
+//    }
+//
+//    auto x = std::views::transform(tc::views::pair_items_view(numbers), [](const auto& p) {
+//        return p.first + p.second;
+//    });
+//
+//    auto y = tc::views::pair_items_view(numbers) | std::views::transform([](const auto& p) {
+//        return p.first + p.second;
+//    });
+
+
+    auto foo = views::pair_items(numbers);
+    for (const auto& [first, second] : foo)
     {
         std::cout << first << " " << second << std::endl;
     }
-    
-    auto x = std::views::transform(tc::views::pair_items_view(numbers), [](const auto& p) {
+
+    auto x = std::views::transform(views::pair_items(numbers), [](const auto& p) {
         return p.first + p.second;
     });
+
+    std::cout << "Transformed" << std::endl;
+    for (const auto& item : x)
+    {
+        std::cout << item << std::endl;
+    }
+
+//    auto y = tc::views::pair_views(numbers) | std::views::transform([](const auto& p) {
+//        return p.first + p.second;
+//    });
 
 
     return 0;


### PR DESCRIPTION
- Ranges need to be moveable. The usual way to do this is to store the underlying view directly in the range adaptor, and have a template deduction guide that deduces std::views::all_t, like [here](https://github.com/TartanLlama/ranges/blob/main/include/tl/cartesian_product.hpp#L250). For simplicity, I just changed the reference that you store to a pointer.

todo: 
- create a catch2 based test project
- test the solution with different use cases, different type of ranges, etc.. 